### PR TITLE
Added int16 output support

### DIFF
--- a/sen2nbar/nbar.py
+++ b/sen2nbar/nbar.py
@@ -14,7 +14,7 @@ from .metadata import get_processing_baseline
 from .utils import _extrapolate_c_factor
 
 
-def nbar_SAFE(path: str, cog: bool = True, quiet: bool = False, toint: bool = False) -> None:
+def nbar_SAFE(path: str, cog: bool = True, to_int: bool = False, quiet: bool = False) -> None:
     """Computes the Nadir BRDF Adjusted Reflectance (NBAR) using the SAFE path.
 
     If the processing baseline is greater than 04.00, the DN values are automatically
@@ -27,10 +27,10 @@ def nbar_SAFE(path: str, cog: bool = True, quiet: bool = False, toint: bool = Fa
         SAFE path.
     cog : bool, default = True
         Whether to save the images as Cloud Optimized GeoTIFF (COG).
+    to_int : bool, default = False
+        Whether to convert the NBAR output to integer.
     quiet : bool, default = False
         Whether to show progress.
-    toint : bool, default = False
-        Whether to convert the NBAR output to integer.
 
     Returns
     -------
@@ -94,7 +94,7 @@ def nbar_SAFE(path: str, cog: bool = True, quiet: bool = False, toint: bool = Fa
         # Compute the NBAR
         img = img * interpolated
 
-        if toint:
+        if to_int:
             img = img.round().astype("int16")
 
         # Save the image

--- a/sen2nbar/nbar.py
+++ b/sen2nbar/nbar.py
@@ -14,7 +14,7 @@ from .metadata import get_processing_baseline
 from .utils import _extrapolate_c_factor
 
 
-def nbar_SAFE(path: str, cog: bool = True, quiet: bool = False) -> None:
+def nbar_SAFE(path: str, cog: bool = True, quiet: bool = False, toint: bool = False) -> None:
     """Computes the Nadir BRDF Adjusted Reflectance (NBAR) using the SAFE path.
 
     If the processing baseline is greater than 04.00, the DN values are automatically
@@ -29,6 +29,8 @@ def nbar_SAFE(path: str, cog: bool = True, quiet: bool = False) -> None:
         Whether to save the images as Cloud Optimized GeoTIFF (COG).
     quiet : bool, default = False
         Whether to show progress.
+    toint : bool, default = False
+        Whether to convert the NBAR output to integer.
 
     Returns
     -------
@@ -91,6 +93,9 @@ def nbar_SAFE(path: str, cog: bool = True, quiet: bool = False) -> None:
 
         # Compute the NBAR
         img = img * interpolated
+
+        if toint:
+            img = img.round().astype("int16")
 
         # Save the image
         img.rio.to_raster(f"{nbar_output_path}{filename}", driver=driver)


### PR DESCRIPTION
First: thank you for this amazing library 👏

I just tested the library and when I used `nbar_SAFE()` the output size for one 10m band was ~1.3Gb and for the 20m band it was ~300Mb. Since I want to apply it to +300 scenes, my storage can't handle these sizes (~7Gb/scene).

I added integer conversion output for reducing 10m bands to ~300Mb and 20m bands to ~80Mb. Now one scene sizes around 1.6Gb (~20% of the initial size)